### PR TITLE
feat: accept old variant spelling of supersede

### DIFF
--- a/adr_viewer/__init__.py
+++ b/adr_viewer/__init__.py
@@ -36,7 +36,7 @@ def parse_adr_to_config(path):
         status = 'amended'
     elif any([line.startswith("Accepted") for line in status]):
         status = 'accepted'
-    elif any([line.startswith("Superseded by") for line in status]):
+    elif any([line.startswith("Superseded by") or line.startswith("Superceded by") for line in status]):
         status = 'superseded'
     elif any([line.startswith("Pending") for line in status]):
         status = 'pending'

--- a/adr_viewer/test_adr_viewer.py
+++ b/adr_viewer/test_adr_viewer.py
@@ -24,6 +24,10 @@ def test_should_mark_superseded_records():
 
     assert config['status'] == 'superseded'
 
+def test_should_mark_old_superceded_records():
+    config = parse_adr_to_config('doc/adr/0007-this-one-will-be-superseded-old-style.md')
+
+    assert config['status'] == 'superseded'
 
 def test_should_mark_amended_records():
     config = parse_adr_to_config('doc/adr/0004-distinguish-superseded-records-with-colour.md')

--- a/doc/adr/0007-this-one-will-be-superseded-old-style.md
+++ b/doc/adr/0007-this-one-will-be-superseded-old-style.md
@@ -1,0 +1,23 @@
+# 7. This one will be superseded old style
+
+Date: 2022-05-01
+
+## Status
+
+Superceded by [8. Accept looking at older spelling of supersede](0008-accept-looking-at-older-spelling-of-supersede.md)
+
+## Context
+
+The original scripts version still uses the alternate spelling supercede and
+not the correct spelline supersede. This spelling was fixed for this viewer
+but doesn't match docs already created with the older version.
+
+## Decision
+
+Don't worry about it. Just change to the new spelling even if the orignal
+tool isn't changed yet.
+
+## Consequences
+
+This will leave old spelled ADR's with a question mark in the html instead
+of as superseded.

--- a/doc/adr/0008-accept-looking-at-older-spelling-of-supersede.md
+++ b/doc/adr/0008-accept-looking-at-older-spelling-of-supersede.md
@@ -1,0 +1,21 @@
+# 8. Accept looking at older spelling of supersede
+
+Date: 2022-05-01
+
+## Status
+
+Accepted
+
+Supercedes [7. This one will be superseded old style](0007-this-one-will-be-superseded-old-style.md)
+
+## Context
+
+The original scripts version still uses the alternate spelling supercede and not the correct spelline supersede. This spelling was fixed for this viewer but doesn't match docs already created with the older version.
+
+## Decision
+
+Accept the older spelling along with the correct spelling for parsing the config options.
+
+## Consequences
+
+What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.


### PR DESCRIPTION
The original adr-tools used the spelling "supercede". The spelling was corrected in this tool
but it now handles any older spelling ADRs as unknown. This change accepts the older
spelling.